### PR TITLE
added mf2j to the list of parsers that can be tested

### DIFF
--- a/config.json
+++ b/config.json
@@ -32,6 +32,14 @@
 			"url": "http://mf2.vendaria.net/parse",
 			"projectUrl": "https://github.com/andyleap/microformats",
 			"authors": ["Andy Leap"]
+		}, {
+			"name": "mf2j",
+			"method": "post",
+			"htmlPropertyName": "html",
+			"baseURLPropertyName": "url",
+			"url": "https://mf2j.herokuapp.com",
+			"projectUrl": "https://github.com/kylewm/mf2j",
+			"authors": ["Kyle Mahan"]
 		}
 	],
 	"versions": [

--- a/lib/testRunner.js
+++ b/lib/testRunner.js
@@ -112,11 +112,21 @@
         }
       })
     }
-    
+
     // if API is POST based
     if(parserConfig.method === 'post'){
       var url = parserConfig.url;
-      var req = request.post(url, {strictSSL: false}, function (err, response, body) {
+
+      var form = {}
+      form[parserConfig.htmlPropertyName] = test.html;
+      if(parserConfig.baseURLPropertyName){
+        form[parserConfig.baseURLPropertyName] = 'http://example.com';
+      }
+      if(parserConfig.strictProperty){
+        form[parserConfig.strictProperty] = parserConfig.strictPropertyValue;
+      }
+
+      var req = request.post(url, {form: form, strictSSL: false}, function (err, response, body) {
         if (!err && response.statusCode == 200) {
           out.result = JSON.parse(body);
           callback(null, out);
@@ -124,15 +134,6 @@
           callback(err, out);
         }
       });
-      // add form fileds
-      var form = req.form();
-      form.append(parserConfig.htmlPropertyName, test.html);
-      if(parserConfig.baseURLPropertyName){
-        form.append(parserConfig.baseURLPropertyName, 'http://example.com');
-      }
-      if(parserConfig.strictProperty){
-        form.append(parserConfig.strictProperty, parserConfig.strictPropertyValue);
-      }
     }
     
   }


### PR DESCRIPTION
- also had to rearrange request.post call so it would use
  application/x-www-urlencoded instead of form/mutli-part which
  Jetty does not handle well apparently.
